### PR TITLE
Switch to elm-test 0.18.4

### DIFF
--- a/bin/cli-helpers.js
+++ b/bin/cli-helpers.js
@@ -3,55 +3,6 @@ var fs = require('fs');
 var fsExtra = require("fs-extra");
 var mkdirp = require("mkdirp");
 
-function createDocTest(testsDocPath, tests, cb) {
-  mkdirp(testsDocPath, function(err) {
-    if (err) {
-      console.error(err);
-      process.exit(-1);
-      return;
-    }
-
-    fsExtra.copySync(
-      path.resolve(__dirname,'./templates/Main.elm'),
-      path.join(testsDocPath, 'Main.elm')
-    );
-    fs.writeFile(
-      path.join(testsDocPath, "Tests.elm"),
-      testsFile(tests),
-      "utf8",
-      function(err) {
-        if (err) {
-          console.error(err);
-          process.exit(-1);
-          return;
-        }
-        cb();
-    });
-  });
-}
-
-function testsFile(tests) {
-  var testsString = tests.map(function(test) {
-    return "        Doc." + test + "Spec.spec";
-  });
-  var imports = tests.map(function(test) {
-    return "import Doc." + test + "Spec";
-  });
-  return [
-    "module Doc.Tests exposing (..)",
-    "",
-    "import Test exposing (..)",
-    "import Expect",
-    imports.join("\n"),
-    "",
-    "",
-    "all : Test",
-    "all =",
-    "    describe \"DocTests\"",
-    "    [\n", testsString.join(",\n") + "    ]"
-  ].join("\n");
-}
-
 function loadDocTestConfig(configPath) {
   /* load the doc test config if we can find it
      otherwise, copy the template one and load that
@@ -75,6 +26,5 @@ function loadDocTestConfig(configPath) {
 }
 
 module.exports =  {
-    loadDocTestConfig: loadDocTestConfig,
-    createDocTest: createDocTest
+    loadDocTestConfig: loadDocTestConfig
 }

--- a/bin/modes.js
+++ b/bin/modes.js
@@ -116,69 +116,67 @@ function generate(model, allTestsGenerated) {
     return;
   }
 
-  helpers.createDocTest(testsDocPath, config.tests, function() {
-    var app = Elm.DocTest.worker(config);
+  var app = Elm.DocTest.worker(config);
 
-    app.ports.readFile.subscribe(function(test) {
-      var pathToModule = path.join(
-        testsPath,
-        config.root,
-        elmModuleToPath(test)
-      );
-      fs.readFile(
-          pathToModule,
-          "utf8",
-          function(err, data) {
-        if (err) {
-          console.error(err);
-          process.exit(-1);
-          return;
-        }
-        app.ports.generateModuleDoctest.send([test, data]);
-      });
-    });
-
-    var writtenTests = 0;
-    app.ports.writeFile.subscribe(function(data) {
-      var test = data[1];
-      var parts = data[0].split(".");
-      var modulePath = [];
-      var moduleName = ".";
-
-      if (parts.length > 1) {
-        modulePath = parts.slice(0, -1);
-        moduleName = parts.slice(-1)[0];
-      } else {
-        moduleName = parts[0];
+  app.ports.readFile.subscribe(function(test) {
+    var pathToModule = path.join(
+      testsPath,
+      config.root,
+      elmModuleToPath(test)
+    );
+    fs.readFile(
+        pathToModule,
+        "utf8",
+        function(err, data) {
+      if (err) {
+        console.error(err);
+        process.exit(-1);
+        return;
       }
+      app.ports.generateModuleDoctest.send([test, data]);
+    });
+  });
 
-      var testsDocModulePath = path.join(
-        testsDocPath,
-        modulePath.join("/")
-      );
+  var writtenTests = 0;
+  app.ports.writeFile.subscribe(function(data) {
+    var test = data[1];
+    var parts = data[0].split(".");
+    var modulePath = [];
+    var moduleName = ".";
 
-      mkdirp(testsDocModulePath, function(err) {
-        if (err) {
-          console.error(err);
-          process.exit(-1);
-          return;
-        }
-        fs.writeFile(
-          path.join(testsDocModulePath, moduleName + "Spec.elm"),
-          test,
-          "utf8",
-          function(err) {
-            if (err) {
-              console.error(err);
-              process.exit(-1);
-              return;
-            }
+    if (parts.length > 1) {
+      modulePath = parts.slice(0, -1);
+      moduleName = parts.slice(-1)[0];
+    } else {
+      moduleName = parts[0];
+    }
 
-            writtenTests = writtenTests + 1;
-            if (writtenTests === config.tests.length && allTestsGenerated) {
-              allTestsGenerated();
-            }
-        });
+    var testsDocModulePath = path.join(
+      testsDocPath,
+      modulePath.join("/")
+    );
+
+    mkdirp(testsDocModulePath, function(err) {
+      if (err) {
+        console.error(err);
+        process.exit(-1);
+        return;
+      }
+      fs.writeFile(
+        path.join(testsDocModulePath, moduleName + "Spec.elm"),
+        test,
+        "utf8",
+        function(err) {
+          if (err) {
+            console.error(err);
+            process.exit(-1);
+            return;
+          }
+
+          writtenTests = writtenTests + 1;
+          if (writtenTests === config.tests.length && allTestsGenerated) {
+            allTestsGenerated();
+          }
       });
     });
   });

--- a/example/tests/elm-package.json
+++ b/example/tests/elm-package.json
@@ -9,9 +9,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
-        "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
+        "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublish": "npm run-script elm-make",
     "test": "./run-tests.sh",
     "elm-make": "elm-make src/DocTest.elm --output bin/elm.js",
-    "start": "npm run-script elm-make && cd example && ../bin/cli.js && ../node_modules/.bin/elm-test tests/Doc/Main.elm",
+    "start": "npm run-script elm-make && cd example && ../bin/cli.js && ../node_modules/.bin/elm-test",
     "release-major": "xyz --repo git@github.com:stoeffel/elm-doc-test.git --increment major",
     "release-minor": "xyz --repo git@github.com:stoeffel/elm-doc-test.git --increment minor",
     "release-patch": "xyz --repo git@github.com:stoeffel/elm-doc-test.git --increment patch"
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "elm": "^0.18.0",
-    "elm-test": "^0.18.2",
+    "elm-test": "^0.18.4",
     "xyz": "^1.1.0"
   }
 }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,7 +4,7 @@ elm-make src/DocTest.elm --output bin/elm.js &&
 cd example &&
 ../bin/cli.js &&
 {
-  elm-test tests/Doc/Main.elm | grep 'Passed:   10' &&
+  elm-test | grep 'Passed:   10' &&
   echo "👍"
 } || {
   echo "Expected 10 passing specs!"


### PR DESCRIPTION
Using latest elm-test, some of the files generated by elm-doc-test
become redundant and/or breaking. Removing all but the actual specs mean
running `elm-test` from the project root after generating the tests,
will automatically pick them up.